### PR TITLE
Add assert_expression test

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,7 +23,5 @@ model-paths:
 - "prophecy-sources"
 macro-paths:
 - "macros"
-test-paths:
-- "tests/generic"
 target-path: "target"
 

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.11.dev3",
+    version="1.0.11.dev4",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.11.dev3
+version: 1.0.11.dev4
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''

--- a/tests/generic/assert_expression.sql
+++ b/tests/generic/assert_expression.sql
@@ -1,0 +1,10 @@
+{% test assert_expression(model, expression, column_name=None) %}
+
+{% set column_list = '*' if should_store_failures() else "1" %}
+
+select
+    {{ column_list }}
+from {{ model }}
+where not(COALESCE({{ expression }}, FALSE))
+
+{% endtest %}


### PR DESCRIPTION
Brief: Add test assert_expression again which is to be used as our custom implementation of dbt_utils.expression_is_true, properly handling expressions evaluating to NULL and not requiring column name to be a prefix of the expression. It was accidentally deleted in a recent PR

PR to fix: https://app.asana.com/1/711615303573503/project/1201259583869898/task/1213907802564307?focus=true