### PR TITLE
Make output column suffix of Regex gem configurable in Replace mode

### DIFF
--- a/gems/Regex.py
+++ b/gems/Regex.py
@@ -47,6 +47,7 @@ class Regex(MacroSpec):
         # Replace
         replacementText: Optional[str] = ""
         copyUnmatchedText: bool = False
+        replaceOutputSuffix: str = "_replaced"
         # Tokenize
         tokenizeOutputMethod: str = "splitColumns"
         noOfColumns: int = 1
@@ -270,6 +271,11 @@ class Regex(MacroSpec):
                                     .addElement(
                                         Checkbox("Copy Unmatched Text to Output")
                                         .bindProperty("copyUnmatchedText")
+                                    )
+                                    .addElement(
+                                        TextBox("Output Column Suffix")
+                                        .bindPlaceholder("Enter suffix for output column")
+                                        .bindProperty("replaceOutputSuffix")
                                     )
                                 )
                             ).otherwise(
@@ -669,6 +675,7 @@ class Regex(MacroSpec):
             safe_str(props.outputRootName),
             safe_str(props.matchColumnName),
             str(props.errorIfNotMatched).lower(),
+            safe_str(props.replaceOutputSuffix),
         ]
         # Join all parameters - don't filter out empty strings, use "''" instead
         non_empty_param = ",".join(parameter_list)
@@ -709,6 +716,7 @@ class Regex(MacroSpec):
             matchColumnName=parametersMap.get('matchColumnName').lstrip("'").rstrip("'"),
             errorIfNotMatched=parametersMap.get("errorIfNotMatched").lower()
                               == "true",
+            replaceOutputSuffix=parametersMap.get("replaceOutputSuffix", "'_replaced'").lstrip("'").rstrip("'"),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:
@@ -740,6 +748,7 @@ class Regex(MacroSpec):
                 MacroParameter("outputRootName", str(properties.outputRootName)),
                 MacroParameter("matchColumnName", str(properties.matchColumnName)),
                 MacroParameter("errorIfNotMatched", str(properties.errorIfNotMatched).lower()),
+                MacroParameter("replaceOutputSuffix", str(properties.replaceOutputSuffix)),
             ],
         )
 
@@ -771,6 +780,9 @@ class Regex(MacroSpec):
         match_column_name = self.props.matchColumnName
         error_if_not_matched = self.props.errorIfNotMatched
         extra_columns_handling = self.props.extraColumnsHandling
+        replace_output_suffix = self.props.replaceOutputSuffix
+        if not replace_output_suffix:
+            replace_output_suffix = "_replaced"
 
         regex_pattern = regex_expression
         if case_insensitive:
@@ -788,7 +800,7 @@ class Regex(MacroSpec):
                 ).otherwise(col(selected_column))
 
             result_df = result_df.withColumn(
-                f"{selected_column}_replaced",
+                f"{selected_column}{replace_output_suffix}",
                 replaced_col
             )
 

--- a/macros/Regex.sql
+++ b/macros/Regex.sql
@@ -52,7 +52,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false) -%}
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced') -%}
     {{ return(adapter.dispatch('Regex', 'prophecy_basics')(relation_name,
     parseColumns,
     schema,
@@ -68,7 +69,8 @@
     extraColumnsHandling,
     outputRootName,
     matchColumnName,
-    errorIfNotMatched)) }}
+    errorIfNotMatched,
+    replaceOutputSuffix)) }}
 {% endmacro %}
 
 {# ============================================ #}
@@ -90,7 +92,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -131,9 +134,9 @@
             when {{ quoted_selected }} rlike '{{ regex_pattern }}' then
                 regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}')
             else {{ quoted_selected }}
-        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     from {{ source_table }}
 
@@ -365,7 +368,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -404,9 +408,9 @@
             WHEN REGEXP_LIKE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ regex_params }}') THEN
                 REGEXP_REPLACE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ escaped_replacement }}', 1, 0, '{{ regex_params }}')
             ELSE {{ quoted_selected }}
-        END AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        END AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        REGEXP_REPLACE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ escaped_replacement }}', 1, 0, '{{ regex_params }}') AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        REGEXP_REPLACE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ escaped_replacement }}', 1, 0, '{{ regex_params }}') AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     FROM {{ source_table }}
 
@@ -623,7 +627,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -665,9 +670,9 @@
             when REGEXP_CONTAINS({{ quoted_selected }}, r'{{ regex_pattern }}') then
                 REGEXP_REPLACE({{ quoted_selected }}, r'{{ regex_pattern }}', '{{ escaped_replacement }}')
             else {{ quoted_selected }}
-        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        REGEXP_REPLACE({{ quoted_selected }}, r'{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        REGEXP_REPLACE({{ quoted_selected }}, r'{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     from {{ source_table }}
 
@@ -905,7 +910,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -946,9 +952,9 @@
             when REGEXP_MATCHES({{ quoted_selected }}, '{{ regex_pattern }}') then
                 regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}')
             else {{ quoted_selected }}
-        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     from {{ source_table }}
 

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -497,9 +497,6 @@ macros:
       - name: "errorIfNotMatched"
         type: "value"
         description: "{\"ProphecyType\": \"value\"}"
-      - name: "replaceOutputSuffix"
-        type: "value"
-        description: "{\"ProphecyType\": \"value\"}"
     macroType: "query"
   - name: "GenerateRows"
     arguments:

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -497,6 +497,9 @@ macros:
       - name: "errorIfNotMatched"
         type: "value"
         description: "{\"ProphecyType\": \"value\"}"
+      - name: "replaceOutputSuffix"
+        type: "value"
+        description: "{\"ProphecyType\": \"value\"}"
     macroType: "query"
   - name: "GenerateRows"
     arguments:


### PR DESCRIPTION
For Regex gem, in replace mode the default suffix was `_replaced` which is in lower case and was causing schema issues in Snowflake where column names are needed in uppercase for correct transpilation. So, made this field configurable.

Testing : 
This is how new Regex gem gets created in IDE ->
<img width="1308" height="834" alt="image" src="https://github.com/user-attachments/assets/aaed0a1b-3a69-4794-942c-edfa59fbb8b9" />

This is a transpiled regex gem (in Snowflake)->
<img width="1466" height="853" alt="image" src="https://github.com/user-attachments/assets/1d70284c-0150-4789-a399-3c5fbe36041f" />

Asana : https://app.asana.com/1/711615303573503/project/1201592195927998/task/1214065674259616?focus=true

