### PR TITLE
snowflake regex suffix changes

### DIFF
--- a/gems/Regex.py
+++ b/gems/Regex.py
@@ -47,6 +47,7 @@ class Regex(MacroSpec):
         # Replace
         replacementText: Optional[str] = ""
         copyUnmatchedText: bool = False
+        replaceOutputSuffix: Optional[str] = "_replaced"
         # Tokenize
         tokenizeOutputMethod: str = "splitColumns"
         noOfColumns: int = 1
@@ -270,6 +271,11 @@ class Regex(MacroSpec):
                                     .addElement(
                                         Checkbox("Copy Unmatched Text to Output")
                                         .bindProperty("copyUnmatchedText")
+                                    )
+                                    .addElement(
+                                        TextBox("Output Column Suffix")
+                                        .bindPlaceholder("Enter suffix for output column")
+                                        .bindProperty("replaceOutputSuffix")
                                     )
                                 )
                             ).otherwise(
@@ -669,6 +675,7 @@ class Regex(MacroSpec):
             safe_str(props.outputRootName),
             safe_str(props.matchColumnName),
             str(props.errorIfNotMatched).lower(),
+            safe_str(props.replaceOutputSuffix),
         ]
         # Join all parameters - don't filter out empty strings, use "''" instead
         non_empty_param = ",".join(parameter_list)
@@ -709,6 +716,7 @@ class Regex(MacroSpec):
             matchColumnName=parametersMap.get('matchColumnName').lstrip("'").rstrip("'"),
             errorIfNotMatched=parametersMap.get("errorIfNotMatched").lower()
                               == "true",
+            replaceOutputSuffix=parametersMap.get("replaceOutputSuffix", "'_replaced'").lstrip("'").rstrip("'"),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:
@@ -740,6 +748,7 @@ class Regex(MacroSpec):
                 MacroParameter("outputRootName", str(properties.outputRootName)),
                 MacroParameter("matchColumnName", str(properties.matchColumnName)),
                 MacroParameter("errorIfNotMatched", str(properties.errorIfNotMatched).lower()),
+                MacroParameter("replaceOutputSuffix", str(properties.replaceOutputSuffix)),
             ],
         )
 
@@ -771,6 +780,9 @@ class Regex(MacroSpec):
         match_column_name = self.props.matchColumnName
         error_if_not_matched = self.props.errorIfNotMatched
         extra_columns_handling = self.props.extraColumnsHandling
+        replace_output_suffix = self.props.replaceOutputSuffix
+        if not replace_output_suffix:
+            replace_output_suffix = "_replaced"
 
         regex_pattern = regex_expression
         if case_insensitive:
@@ -788,7 +800,7 @@ class Regex(MacroSpec):
                 ).otherwise(col(selected_column))
 
             result_df = result_df.withColumn(
-                f"{selected_column}_replaced",
+                f"{selected_column}{replace_output_suffix}",
                 replaced_col
             )
 
@@ -951,4 +963,3 @@ class Regex(MacroSpec):
                 result_df = result_df.filter(col(selected_column).rlike(regex_pattern))
 
         return result_df
-

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.11",
+    version="1.0.12.dev0",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/macros/Regex.sql
+++ b/macros/Regex.sql
@@ -52,7 +52,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false) -%}
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced') -%}
     {{ return(adapter.dispatch('Regex', 'prophecy_basics')(relation_name,
     parseColumns,
     schema,
@@ -68,7 +69,8 @@
     extraColumnsHandling,
     outputRootName,
     matchColumnName,
-    errorIfNotMatched)) }}
+    errorIfNotMatched,
+    replaceOutputSuffix)) }}
 {% endmacro %}
 
 {# ============================================ #}
@@ -90,7 +92,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -131,9 +134,9 @@
             when {{ quoted_selected }} rlike '{{ regex_pattern }}' then
                 regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}')
             else {{ quoted_selected }}
-        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     from {{ source_table }}
 
@@ -365,7 +368,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -404,9 +408,9 @@
             WHEN REGEXP_LIKE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ regex_params }}') THEN
                 REGEXP_REPLACE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ escaped_replacement }}', 1, 0, '{{ regex_params }}')
             ELSE {{ quoted_selected }}
-        END AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        END AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        REGEXP_REPLACE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ escaped_replacement }}', 1, 0, '{{ regex_params }}') AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        REGEXP_REPLACE({{ quoted_selected }}, '{{ escaped_regex }}', '{{ escaped_replacement }}', 1, 0, '{{ regex_params }}') AS {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     FROM {{ source_table }}
 
@@ -623,7 +627,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -665,9 +670,9 @@
             when REGEXP_CONTAINS({{ quoted_selected }}, r'{{ regex_pattern }}') then
                 REGEXP_REPLACE({{ quoted_selected }}, r'{{ regex_pattern }}', '{{ escaped_replacement }}')
             else {{ quoted_selected }}
-        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        REGEXP_REPLACE({{ quoted_selected }}, r'{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        REGEXP_REPLACE({{ quoted_selected }}, r'{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     from {{ source_table }}
 
@@ -905,7 +910,8 @@
     extraColumnsHandling='dropExtraWithoutWarning',
     outputRootName='regex_col',
     matchColumnName='regex_match',
-    errorIfNotMatched=false
+    errorIfNotMatched=false,
+    replaceOutputSuffix='_replaced'
 ) %}
 
 {# Input validation #}
@@ -946,9 +952,9 @@
             when REGEXP_MATCHES({{ quoted_selected }}, '{{ regex_pattern }}') then
                 regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}')
             else {{ quoted_selected }}
-        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        end as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% else %}
-        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ '_replaced') }}
+        regexp_replace({{ quoted_selected }}, '{{ regex_pattern }}', '{{ escaped_replacement }}') as {{ prophecy_basics.quote_identifier(selectedColumnName ~ (replaceOutputSuffix if replaceOutputSuffix else '_replaced')) }}
         {% endif %}
     from {{ source_table }}
 

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.11
+version: 1.0.12.dev0
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
For Regex gem, in replace mode the default suffix was _replaced which is in lower case and was causing schema issues in Snowflake where column names are needed in uppercase for correct transpilation. So, made this field configurable.

Testing :
This is how new Regex gem gets created in IDE ->
<img width="785" height="499" alt="image" src="https://github.com/user-attachments/assets/d0d6f720-b0c7-42fc-bb61-2c9dce7b1bd4" />


This is a transpiled regex gem (in Snowflake)->
<img width="780" height="454" alt="image" src="https://github.com/user-attachments/assets/863c58e0-a0c9-4df8-aa65-afaf6d35a8e6" />


Asana : https://app.asana.com/1/711615303573503/project/1201592195927998/task/1214065674259616?focus=true