### PR TITLE
fix: parse input port schema safely in macro gems

### DIFF
--- a/gems/CountRecords.py
+++ b/gems/CountRecords.py
@@ -146,7 +146,7 @@ class CountRecords(MacroSpec):
         self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -206,7 +206,7 @@ class CountRecords(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/DataCleansing.py
+++ b/gems/DataCleansing.py
@@ -323,7 +323,7 @@ class DataCleansing(MacroSpec):
         self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -455,7 +455,7 @@ class DataCleansing(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/DataEncoderDecoder.py
+++ b/gems/DataEncoderDecoder.py
@@ -615,7 +615,7 @@ class DataEncoderDecoder(MacroSpec):
         self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -769,7 +769,7 @@ class DataEncoderDecoder(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/DataMasking.py
+++ b/gems/DataMasking.py
@@ -413,7 +413,7 @@ class DataMasking(MacroSpec):
         self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -558,7 +558,7 @@ class DataMasking(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/DynamicSelect.py
+++ b/gems/DynamicSelect.py
@@ -224,7 +224,7 @@ class DynamicSelect(MacroSpec):
         if newState.properties.structTypeChecked:
             target_types.append("Struct")
 
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -324,7 +324,7 @@ class DynamicSelect(MacroSpec):
         if component.properties.structTypeChecked:
             target_types.append("Struct")
 
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/FindDuplicates.py
+++ b/gems/FindDuplicates.py
@@ -426,7 +426,7 @@ class FindDuplicates(MacroSpec):
             self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -531,7 +531,7 @@ class FindDuplicates(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/GenerateRows.py
+++ b/gems/GenerateRows.py
@@ -173,7 +173,7 @@ class GenerateRows(MacroSpec):
         return diagnostics
 
     def onChange(self, context: SqlContext, oldState: Component, newState: Component) -> Component:
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -273,7 +273,7 @@ class GenerateRows(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/Imputation.py
+++ b/gems/Imputation.py
@@ -167,8 +167,8 @@ class Imputation(MacroSpec):
         self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         try:
-            raw = str(newState.ports.inputs[0].schema).replace("'", '"')
-            schema = json.loads(raw)
+            _raw = newState.ports.inputs[0].schema
+            schema = json.loads(_raw) if isinstance(_raw, str) else (_raw or {})
         except Exception:
             schema = {"fields": []}
         fields_array = [
@@ -232,8 +232,8 @@ class Imputation(MacroSpec):
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
         try:
-            raw = str(component.ports.inputs[0].schema).replace("'", '"')
-            schema = json.loads(raw)
+            _raw = component.ports.inputs[0].schema
+            schema = json.loads(_raw) if isinstance(_raw, str) else (_raw or {})
         except Exception:
             schema = {"fields": []}
         fields_array = [

--- a/gems/MultiColumnEdit.py
+++ b/gems/MultiColumnEdit.py
@@ -219,7 +219,7 @@ class MultiColumnEdit(MacroSpec):
             self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -296,7 +296,7 @@ class MultiColumnEdit(MacroSpec):
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/MultiColumnRename.py
+++ b/gems/MultiColumnRename.py
@@ -248,7 +248,7 @@ class MultiColumnRename(MacroSpec):
             self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -313,7 +313,7 @@ class MultiColumnRename(MacroSpec):
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/Regex.py
+++ b/gems/Regex.py
@@ -527,7 +527,7 @@ class Regex(MacroSpec):
 
     def onChange(self, context: SqlContext, oldState: Component, newState: Component) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [{"name": field["name"], "dataType": field["dataType"]["type"]} for field in schema["fields"]]
         relation_name = self.get_relation_names(newState, context)
 
@@ -754,7 +754,7 @@ class Regex(MacroSpec):
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [{"name": field["name"], "dataType": field["dataType"]["type"]} for field in schema["fields"]]
         relation_name = self.get_relation_names(component, context)
 

--- a/gems/RunningTotal.py
+++ b/gems/RunningTotal.py
@@ -210,14 +210,21 @@ class RunningTotal(MacroSpec):
 
         return relation_name
 
+    @staticmethod
+    def _fields_from_port_schema(port_schema) -> List[dict]:
+        if isinstance(port_schema, str):
+            schema = json.loads(port_schema or "{}")
+        else:
+            schema = port_schema or {}
+        return [
+            {"name": field["name"], "dataType": field["dataType"]["type"]}
+            for field in schema.get("fields", [])
+        ]
+
     def onChange(
             self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
-        fields_array = [
-            {"name": field["name"], "dataType": field["dataType"]["type"]}
-            for field in schema["fields"]
-        ]
+        fields_array = self._fields_from_port_schema(newState.ports.inputs[0].schema)
         relation_name = self.get_relation_names(newState, context)
 
         newProperties = dataclasses.replace(
@@ -327,11 +334,7 @@ class RunningTotal(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
-        fields_array = [
-            {"name": field["name"], "dataType": field["dataType"]["type"]}
-            for field in schema["fields"]
-        ]
+        fields_array = self._fields_from_port_schema(component.ports.inputs[0].schema)
         relation_name = self.get_relation_names(component, context)
 
         newProperties = dataclasses.replace(

--- a/gems/Sample.py
+++ b/gems/Sample.py
@@ -274,9 +274,7 @@ class Sample(MacroSpec):
         diagnostics = super(Sample, self).validate(context, component)
 
         missingDataColumns = []
-        schemaFields = json.loads(
-            str(component.ports.inputs[0].schema).replace("'", '"')
-        )
+        schemaFields = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fieldsArray = [field["name"].upper() for field in schemaFields["fields"]]
 
         for col in component.properties.dataColumns:
@@ -312,7 +310,7 @@ class Sample(MacroSpec):
             self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -418,7 +416,7 @@ class Sample(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/Tile.py
+++ b/gems/Tile.py
@@ -355,7 +355,7 @@ class Tile(MacroSpec):
 
     def onChange(self, context: SqlContext, oldState: Component, newState: Component) -> Component:
         # Handle changes in the component's state and return the new state
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [{"name": field["name"], "dataType": field["dataType"]["type"]} for field in schema["fields"]]
         relation_name = self.get_relation_names(newState, context)
 
@@ -497,7 +497,7 @@ class Tile(MacroSpec):
             ],
         )
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [{"name": field["name"], "dataType": field["dataType"]["type"]} for field in schema["fields"]]
         relation_name = self.get_relation_names(component, context)
 

--- a/gems/UnionByName.py
+++ b/gems/UnionByName.py
@@ -83,7 +83,7 @@ class UnionByName(MacroSpec):
         """Return list[str] – one compact JSON blob per input port."""
         schema_blobs = []
         for in_port in component.ports.inputs:
-            raw_schema = json.loads(str(in_port.schema).replace("'", '"'))
+            raw_schema = (json.loads(in_port.schema) if isinstance(in_port.schema, str) else (in_port.schema or {}))
             fields_arr = [
                 {"name": f["name"], "dataType": f["dataType"]["type"]}
                 for f in raw_schema["fields"]

--- a/gems/WeightedAverage.py
+++ b/gems/WeightedAverage.py
@@ -168,7 +168,7 @@ class WeightedAverage(MacroSpec):
     def onChange(
             self, context: SqlContext, oldState: Component, newState: Component
     ) -> Component:
-        schema = json.loads(str(newState.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(newState.ports.inputs[0].schema) if isinstance(newState.ports.inputs[0].schema, str) else (newState.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]
@@ -231,7 +231,7 @@ class WeightedAverage(MacroSpec):
         )
 
     def updateInputPortSlug(self, component: Component, context: SqlContext):
-        schema = json.loads(str(component.ports.inputs[0].schema).replace("'", '"'))
+        schema = (json.loads(component.ports.inputs[0].schema) if isinstance(component.ports.inputs[0].schema, str) else (component.ports.inputs[0].schema or {}))
         fields_array = [
             {"name": field["name"], "dataType": field["dataType"]["type"]}
             for field in schema["fields"]

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.14.dev0",
+    version="1.0.14.dev1",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.14.dev0
+version: 1.0.14.dev1
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
The gems parsed the input port schema via json.loads(str(port.schema).replace("'", '"')). port.schema is already a parsed dict at runtime, and the blind quote-swap corrupts any column name or description containing an apostrophe (e.g. "someone's email") by turning the in-string ' into a ", which breaks the JSON and raises "Expecting ',' delimiter". The gem's onChange/updateInputPortSlug then fails, leaving derived properties (relation_name, schema) empty -> empty FROM clause in schema analysis and false "column not present in input schema" diagnostics.

Use the structure directly and only json.loads a genuine string, across all 16 affected gems.