### PR TITLE
Fix apostrophe-in-schema/column breaking Sample gem

### DIFF
--- a/gems/DataEncoderDecoder.py
+++ b/gems/DataEncoderDecoder.py
@@ -674,7 +674,11 @@ class DataEncoderDecoder(MacroSpec):
                 return "''"
             if isinstance(val, list):
                 return str(val)
-            return f"'{val}'"
+            # Escape backslashes and single quotes so values containing
+            # apostrophes (e.g. column names like "Feb' 24") remain a valid
+            # Jinja string literal in the generated macro call.
+            escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
 
         arguments = [
             str(props.relation_name),

--- a/gems/DataMasking.py
+++ b/gems/DataMasking.py
@@ -460,7 +460,11 @@ class DataMasking(MacroSpec):
                 return "''"
             if isinstance(val, list):
                 return str(val)
-            return f"'{val}'"
+            # Escape backslashes and single quotes so values containing
+            # apostrophes (e.g. column names like "Feb' 24") remain a valid
+            # Jinja string literal in the generated macro call.
+            escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
 
         arguments = [
             str(props.relation_name),

--- a/gems/Sample.py
+++ b/gems/Sample.py
@@ -344,7 +344,11 @@ class Sample(MacroSpec):
                 return "''"
             if isinstance(val, list):
                 return str(val)
-            return f"'{val}'"
+            # Escape backslashes and single quotes so values containing
+            # apostrophes (e.g. column names like "Feb' 24" in the schema)
+            # remain a valid Jinja string literal in the generated macro call.
+            escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
 
         non_empty_param = ",".join(
             [

--- a/gems/Tile.py
+++ b/gems/Tile.py
@@ -388,7 +388,11 @@ class Tile(MacroSpec):
                 return "''"
             if isinstance(val, list):
                 return str(val)
-            return f"'{val}'"
+            # Escape backslashes and single quotes so values containing
+            # apostrophes (e.g. column names like "Feb' 24" or the schema)
+            # remain a valid Jinja string literal in the generated macro call.
+            escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
 
         arguments = [
             str(props.relation_name),

--- a/gems/WeightedAverage.py
+++ b/gems/WeightedAverage.py
@@ -190,7 +190,11 @@ class WeightedAverage(MacroSpec):
                 return "''"
             if isinstance(val, list):
                 return str(val)
-            return f"'{val}'"
+            # Escape backslashes and single quotes so values containing
+            # apostrophes (e.g. column names like "Feb' 24") remain a valid
+            # Jinja string literal in the generated macro call.
+            escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
 
         arguments = [
             str(props.relation_name),

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.14",
+    version="1.0.15.dev0",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.14
+version: 1.0.15.dev0
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
Problem: Gems that embed a string (the input schema JS, or column names) into their generated dbt macro call wrapped it in single quotes without escaping. When a column name contains an apostrophe (e.g. Include in `Feb' 24 Inc Summary`, `Katie's Comments`), the `'` terminates the Jinja string literal early, producing: `dbt_common.exceptions.base.CompilationError: expected token ',', got 'integer'`
  
 Fix: Made each affected gem's safe_str helper escape backslashes then single quotes before quoting:
  
  ```
  escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
  return f"'{escaped}'"
  ```

 Gems fixed:
  - Sample.py
  - Tile.py
  - WeightedAverage.py
  - DataMasking.py
  - DataEncoderDecoder.py
  
 
Asana ticket: https://app.asana.com/1/711615303573503/project/1213080773647617/task/1214055945018282?focus=true