### PR TITLE
Text To Column - Fixing Escape Character Issue

### DIFF
--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.15.dev1",
+    version="1.0.15.dev2",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/macros/TextToColumns.sql
+++ b/macros/TextToColumns.sql
@@ -167,9 +167,6 @@ SELECT * FROM {{ relation_list | join(', ') }}
 
 {#
   Build the regex pattern for matching the delimiter.
-  `pattern` keeps the (regex-escaped) delimiter for regex contexts (REGEXP_REPLACE) and is
-  emitted as a BigQuery raw string to avoid "Illegal escape sequence" errors (e.g. '\|').
-  `literal_delimiter` strips the regex escaping for literal contexts (ARRAY_TO_STRING / SPLIT).
 #}
 {%- set pattern = delimiter -%}
 {%- set literal_delimiter = delimiter.replace('\\', '') -%}

--- a/macros/TextToColumns.sql
+++ b/macros/TextToColumns.sql
@@ -167,8 +167,12 @@ SELECT * FROM {{ relation_list | join(', ') }}
 
 {#
   Build the regex pattern for matching the delimiter.
+  `pattern` keeps the (regex-escaped) delimiter for regex contexts (REGEXP_REPLACE) and is
+  emitted as a BigQuery raw string to avoid "Illegal escape sequence" errors (e.g. '\|').
+  `literal_delimiter` strips the regex escaping for literal contexts (ARRAY_TO_STRING / SPLIT).
 #}
 {%- set pattern = delimiter -%}
+{%- set literal_delimiter = delimiter.replace('\\', '') -%}
 {% set relation_list = relation_name if relation_name is iterable and relation_name is not string else [relation_name] %}
 
 {# Helper to quote column names inline #}
@@ -181,7 +185,7 @@ SELECT * FROM {{ relation_list | join(', ') }}
     WITH source AS (
         SELECT *,
             SPLIT(
-                REGEXP_REPLACE({{ quoted_column_name }}, {{ "'" ~ pattern ~ "'" }}, '%%DELIM%%'),
+                REGEXP_REPLACE({{ quoted_column_name }}, {{ "r'" ~ pattern ~ "'" }}, '%%DELIM%%'),
                 '%%DELIM%%'
             ) AS tokens
         FROM {{ relation_list | join(', ') }}
@@ -199,7 +203,7 @@ SELECT * FROM {{ relation_list | join(', ') }}
         {%- if leaveExtraCharLastCol %}
             CASE
                 WHEN ARRAY_LENGTH(tokens) >= {{ noOfColumns }}
-                    THEN ARRAY_TO_STRING(ARRAY(SELECT tokens[OFFSET(i)] FROM UNNEST(GENERATE_ARRAY({{ noOfColumns - 1 }}, ARRAY_LENGTH(tokens) - 1)) AS i), '{{ delimiter }}')
+                    THEN ARRAY_TO_STRING(ARRAY(SELECT tokens[OFFSET(i)] FROM UNNEST(GENERATE_ARRAY({{ noOfColumns - 1 }}, ARRAY_LENGTH(tokens) - 1)) AS i), '{{ literal_delimiter }}')
                 ELSE null
             END AS {{ quote_char ~ splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix ~ quote_char }}
         {%- else %}
@@ -217,7 +221,7 @@ SELECT * FROM {{ relation_list | join(', ') }}
     SELECT r.*,
         REGEXP_REPLACE(split_value, r'[{}_]', ' ') AS {{ quote_char ~ splitRowsColumnName ~ quote_char }}
     FROM {{ relation_list | join(', ') }} r,
-    UNNEST(SPLIT(COALESCE(r.{{ quoted_column_name }}, ''), '{{ pattern }}')) AS split_value
+    UNNEST(SPLIT(COALESCE(r.{{ quoted_column_name }}, ''), '{{ literal_delimiter }}')) AS split_value
 
 {%- else -%}
 SELECT * FROM {{ relation_list | join(', ') }}

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.15.dev1
+version: 1.0.15.dev2
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
**ISSUE**
The frontend ships the delimiter already regex-escaped (gems/TextToColumns.py, line 297: re.escape(...)). 
So | arrives at the macro as \|. That escaping is **correct for regex functions**, but **wrong for the two BigQuery functions that take a literal string**:
- ARRAY_TO_STRING(array, separator) — separator is a literal join string, not a regex.
- SPLIT(value, delimiter) — delimiter is a literal substring, not a regex.

If I passed the escaped \| into those:

1. It causes the Illegal escape sequence: \| compile error (normal string literal can't contain \|).
2. Even if it compiled, the behavior would be wrong — ARRAY_TO_STRING would join tokens with the two characters \| instead of |, and SPLIT would try to split on \| instead of |.

So literal_delimiter = delimiter.replace('\\', '') strips the backslash that re.escape added, turning \| back into | for those literal contexts.

**Test Case**
<img width="1463" height="1002" alt="image" src="https://github.com/user-attachments/assets/f5e31273-ef63-4364-a6dc-1f7a0a262573" />
