### PR TITLE
Fix transpose gem parse_port_schema() bug

### DIFF
--- a/gems/Transpose.py
+++ b/gems/Transpose.py
@@ -33,7 +33,6 @@ class Transpose(MacroSpec):
         nameColumn: str = "Name"
         valueColumn: str = "Value"
 
-    @staticmethod
     def get_relation_names(self, component: Component, context: SqlContext):
         relation_name = []
         for input_port in component.ports.inputs:
@@ -49,6 +48,7 @@ class Transpose(MacroSpec):
                 relation_name.append(upstream_label)
         return relation_name
 
+    @staticmethod
     def _parse_port_schema(schema) -> dict:
         raw = str(schema)
         try:

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.15.dev4",
+    version="1.0.15.dev5",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.15.dev4
+version: 1.0.15.dev5
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
1. Symptom: Transpose._parse_port_schema() takes 1 positional argument but 2 were given whenever the gem read its input-port schema (diff dialog, state changes, code-gen).                                    
2. Root cause: PR #78 (7710403) inserted a new `get_relation_names` method between the `@staticmethod `decorator and `def _parse_port_schema`, shifting the decorator onto the wrong method.                         
3. Effect: `_parse_port_schema` lost `@staticmethod` (so self was wrongly injected → the error), and `get_relation_names` wrongly gained it (a latent second bug that would drop a context argument).       
          
**Fix:** Restored @staticmethod on _parse_port_schema and removed it from get_relation_names, matching each method's signature.

Asana link: https://app.asana.com/1/711615303573503/project/1201755380090772/task/1216293626804297?focus=true