### PR TITLE
Fix Regex loadProperties: parse macro args with ast.literal_eval so r…

### DIFF
--- a/gems/Regex.py
+++ b/gems/Regex.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 from dataclasses import dataclass, field
 import json
@@ -680,9 +681,24 @@ class Regex(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list/tuple params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads with a
+            # naive .replace("'", '"'), which corrupts any regex containing a
+            # double-quote (e.g. ([^"]+), common in Alteryx-transpiled pipelines)
+            # and raises JSONDecodeError, wiping the gem's config. literal_eval
+            # accepts both single- and double-quoted literals, so JSON also works.
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         parseColumns = []
-        # Double-escape backslashes and convert quotes to make valid JSON for json.loads()
-        parseCols = json.loads(parametersMap.get('parseColumns').replace('\\', '\\\\').replace("'", '"'))
+        parseCols = _parse_py_literal(parametersMap.get('parseColumns'), [])
         for fld in parseCols:
             parseColumns.append(
                 ColumnParse(
@@ -692,7 +708,7 @@ class Regex(MacroSpec):
                 )
             )
         return Regex.RegexProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             parseColumns=parseColumns,
             schema=parametersMap.get('schema').lstrip("'").rstrip("'"),
             selectedColumnName=parametersMap.get('selectedColumnName').lstrip("'").rstrip("'"),

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.15",
+    version="1.0.16.dev0",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.15
+version: 1.0.16.dev0
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
### What was wrong
`Regex.loadProperties` parsed the `parseColumns` (and `relation_name`) macro args with `json.loads(...replace("'", '"'))`. But `apply()` emits those args as `str(<python list>)` (single-quoted Python repr), not JSON. The blanket `'` → `"` replace corrupts any regex containing a literal double-quote — e.g. `([^"]+)`, extremely common in Alteryx-transpiled pipelines — producing invalid JSON and raising `JSONDecodeError`.

The parse failure means the gem loses its typed config, and the next time an upstream schema change triggers `onChange`/`apply`, the Regex gem is re-emitted with `parseColumns=[]` → the pipeline fails validation with "Column Name is required" / "Regex Expression is required". The SQL still runs at rest, so it stays latent until an upstream schema change.

### Fix
Parse the macro args with `ast.literal_eval` — the correct inverse of `apply()`'s `str(list)` emit. It preserves double-quotes and backslashes in the regex, accepts both single- and double-quoted literals (so JSON from `unloadProperties` still works), and falls back to the default instead of crashing on malformed input.

### Verification
- Round-trip confirmed for the double-quote regex case, single-quote values, JSON form, and empty/None.
- Validated end-to-end: renaming an upstream column (which changes a Regex gem's input schema and previously wiped its config) now preserves the Regex configuration.

Note: the same `.replace("'", '"')` pattern exists in ~21 other prophecy_basics gems — not addressed here.
