### PR TITLE
RegEx Delimiter Support - TextToColumns

### DIFF
--- a/gems/TextToColumns.py
+++ b/gems/TextToColumns.py
@@ -289,12 +289,27 @@ class TextToColumns(MacroSpec):
         )
         return newState.bindProperties(newProperties)
 
+    def _is_regex_delimiter(self, delimiter: str) -> bool:
+        # Auto-detect whether the delimiter is meant as a regex pattern or a plain literal.
+        # Regex intent is assumed when the delimiter contains a character class [...],
+        # a group (...), or a backslash escape (\t, \n, \d, \s, \|, ...). Everything else
+        # (e.g. |, ., ,, ;, plain text) is treated as a literal.
+        return bool(
+            re.search(r"\[.+?\]", delimiter)
+            or re.search(r"\(.+?\)", delimiter)
+            or "\\" in delimiter
+        )
+
     def apply(self, props: TextToColumnsProperties) -> str:
         # You can now access self.relation_name here
         resolved_macro_name = f"{self.projectName}.{self.name}"
 
-        # Handle delimiter with special characters
-        escaped_delimiter = re.escape(props.delimiter).replace('\\ ', ' ')
+        # Regex delimiters (e.g. [,], \d+) are passed through untouched; literal delimiters
+        # (e.g. |, ., ;) are re.escaped so their regex-special characters match literally.
+        if self._is_regex_delimiter(props.delimiter):
+            escaped_delimiter = props.delimiter
+        else:
+            escaped_delimiter = re.escape(props.delimiter).replace('\\ ', ' ')
 
         arguments = [
             str(props.relation_name),

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.16.dev2",
+    version="1.0.16.dev3",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.15",
+    version="1.0.16.dev0",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/macros/TextToColumns.sql
+++ b/macros/TextToColumns.sql
@@ -9,50 +9,54 @@
   Parameters:
     - relation_name (list): Source relation(s).
     - columnNames: Single column name to split (string).
-    - delimiter: Pattern used in regexp_replace / split (literal delimiter string).
+    - delimiter: REGEX pattern used to split. Plain text (',', ';', '\t') works as-is;
+      regex is honored too (e.g. '[,]', '[|]', '\\s*,\\s*'). To match a regex
+      metacharacter literally (. | ( ) [ ] { } ^ $ * + ? \), escape it or wrap it in
+      a character class (e.g. '[|]' for a pipe, '[.]' for a dot).
     - split_strategy: 'splitColumns' | 'splitRows' | other → SELECT * pass-through.
     - noOfColumns: Number of output pieces for splitColumns.
-    - leaveExtraCharLastCol: True / 'Leave extra in last column' (Snowflake/DuckDB) — merge overflow into last column.
+    - leaveExtraCharLastCol: True / 'Leave extra in last column' — merge overflow into last column.
+      (Overflow is rejoined using the delimiter text; lossless for plain delimiters, best-effort for regex.)
     - splitColumnPrefix, splitColumnSuffix: Name pattern prefix_i_suffix for split columns.
     - splitRowsColumnName: Output token column for splitRows.
 
+  Behavior (aligned across all adapters):
+    - The delimiter is always treated as a regex, implemented uniformly as
+      REGEXP_REPLACE(col, <delimiter>, '%%DELIM%%') then split on the '%%DELIM%%' sentinel.
+    - Split tokens are returned verbatim (no quote stripping / no character replacement).
+
   Adapter Support:
-    - default__ (Spark), bigquery__, snowflake__, duckdb__
+    - default__ (Spark/Databricks), bigquery__, snowflake__, duckdb__
 
   Depends on schema parameter:
     No
 
   Macro Call Examples (default__):
     {{ prophecy_basics.TextToColumns(['t'], 'payload', ',', 'splitColumns', 4, False, 'c', 'out', 'token') }}
-    {{ prophecy_basics.TextToColumns(['t'], 'payload', '|', 'splitRows', 1, False, 'in', 'out', 'part') }}
+    {{ prophecy_basics.TextToColumns(['t'], 'payload', '[|]', 'splitRows', 1, False, 'in', 'out', 'part') }}
 
   CTE Usage Example:
     Macro call (first example above):
       {{ prophecy_basics.TextToColumns(['t'], 'payload', ',', 'splitColumns', 4, False, 'c', 'out', 'token') }}
 
     Resolved query (default__ — splitColumns; abbreviated column list):
-      WITH params AS (
-          SELECT *, ',' AS delimiter, 4 AS num_cols
-          FROM t
-      ),
-      split_result AS (
+      WITH source AS (
           SELECT *,
               SPLIT(
-                  `payload`,
-                  CONCAT('[', REGEXP_REPLACE(delimiter, '([\\\\\\]\\[\\^\\-])', '\\\\$1'), ']'),
-                  num_cols
-              ) AS parts
-          FROM params
+                  REGEXP_REPLACE(`payload`, ',', '%%DELIM%%'),
+                  '%%DELIM%%'
+              ) AS tokens
+          FROM t
       ),
-      final AS (
-          SELECT * EXCEPT(delimiter, num_cols, parts),
-              parts[0] AS `c_1_out`,
-              parts[1] AS `c_2_out`,
-              parts[2] AS `c_3_out`,
-              parts[3] AS `c_4_out`
-          FROM split_result
+      all_data AS (
+          SELECT *,
+              tokens[0] AS `c_1_out`,
+              tokens[1] AS `c_2_out`,
+              tokens[2] AS `c_3_out`,
+              tokens[3] AS `c_4_out`
+          FROM source
       )
-      SELECT * FROM final
+      SELECT * EXCEPT(tokens) FROM all_data
 #}
 {% macro TextToColumns(relation_name,
     columnNames,
@@ -93,8 +97,13 @@
 
 {# Quote the column name properly #}
 {%- set quoted_column_name = prophecy_basics.quote_identifier(columnNames) | trim -%}
-{%- set delimiter_literal = prophecy_basics.escape_sql_string(delimiter) -%}
-{%- set split_pattern_expr = "CONCAT('[', REGEXP_REPLACE(delimiter, '([\\\\\\\\\\\\]\\\\[\\\\^\\\\-])', '\\\\\\\\$1'), ']')" -%}
+{# The gem auto-detects literal vs regex delimiters: a literal like | or . arrives
+   already re.escaped (\| , \.), while a regex like [,] or \d+ arrives as-is. Escape the
+   backslashes (escape_backslashes=true) so Sparks string parser does NOT strip them and
+   the regex engine receives exactly what the gem intended (\| -> literal pipe, \d -> digit
+   class, [,] -> comma). The delimiter is used directly as the split regex below (no extra
+   [] wrapping, which previously split on a leading [ and produced an empty first column). #}
+{%- set delimiter_literal = prophecy_basics.escape_sql_string(delimiter, escape_backslashes=true) -%}
 
 {%- if split_strategy == 'splitColumns' -%}
     WITH params AS (
@@ -107,7 +116,7 @@
         SELECT *,
             SPLIT(
                 {{ quoted_column_name }},
-                {{ split_pattern_expr }},
+                '{{ delimiter_literal }}',
                 num_cols
             ) AS parts
         FROM params
@@ -138,12 +147,12 @@
         SELECT *,
             SPLIT(
                 if({{ quoted_column_name }} IS NULL, '', {{ quoted_column_name }}),
-                {{ split_pattern_expr }}
+                '{{ delimiter_literal }}'
             ) AS parts
         FROM params
     )
     SELECT r.* EXCEPT({{ split_rows_except_columns | join(', ') }}),
-            (regexp_replace(s.col, '[{}_]', ' ')) AS {{ quote_char ~ splitRowsColumnName ~ quote_char }}
+            s.col AS {{ quote_char ~ splitRowsColumnName ~ quote_char }}
     FROM split_result r
     LATERAL VIEW explode(parts) s AS col
 
@@ -169,7 +178,11 @@ SELECT * FROM {{ relation_list | join(', ') }}
   Build the regex pattern for matching the delimiter.
 #}
 {%- set pattern = delimiter -%}
-{%- set literal_delimiter = delimiter.replace('\\', '') -%}
+{# BigQuery string literals — including raw r'...' — cannot contain a bare newline or
+   carriage return, which raises "Unclosed raw string literal". dbt turns a \n / \r
+   delimiter into a real control character, so re-encode those as regex escapes: inside a
+   raw string \n and \r are matched as newline / carriage return by the regex engine. #}
+{%- set pattern = pattern | replace('\n', '\\n') | replace('\r', '\\r') -%}
 {% set relation_list = relation_name if relation_name is iterable and relation_name is not string else [relation_name] %}
 
 {# Helper to quote column names inline #}
@@ -177,6 +190,8 @@ SELECT * FROM {{ relation_list | join(', ') }}
 
 {# Quote the column name properly #}
 {%- set quoted_column_name = prophecy_basics.quote_identifier(columnNames) -%}
+{# Delimiter is treated as a regex: convert matches to a sentinel then split on it. #}
+{%- set leave_extra = (leaveExtraCharLastCol == true or leaveExtraCharLastCol == 'Leave extra in last column' or leaveExtraCharLastCol == 'true' or leaveExtraCharLastCol == 'True') -%}
 
 {%- if split_strategy == 'splitColumns' -%}
     WITH source AS (
@@ -193,20 +208,19 @@ SELECT * FROM {{ relation_list | join(', ') }}
         {%- for i in range(1, noOfColumns) %}
             CASE
                 WHEN ARRAY_LENGTH(tokens) > {{ i - 1 }}
-                    THEN REGEXP_REPLACE((tokens[OFFSET({{ i - 1 }})]), r'^"|"$', '')
+                    THEN tokens[OFFSET({{ i - 1 }})]
                 ELSE null
-            END AS {{ quote_char ~ splitColumnPrefix ~ '_' ~ i ~ '_' ~ splitColumnSuffix ~ quote_char }}{% if not loop.last or leaveExtraCharLastCol %}, {% endif %}
-        {%- endfor %}
-        {%- if leaveExtraCharLastCol %}
+            END AS {{ quote_char ~ splitColumnPrefix ~ '_' ~ i ~ '_' ~ splitColumnSuffix ~ quote_char }}, {% endfor %}
+        {%- if leave_extra %}
             CASE
                 WHEN ARRAY_LENGTH(tokens) >= {{ noOfColumns }}
-                    THEN ARRAY_TO_STRING(ARRAY(SELECT tokens[OFFSET(i)] FROM UNNEST(GENERATE_ARRAY({{ noOfColumns - 1 }}, ARRAY_LENGTH(tokens) - 1)) AS i), '{{ literal_delimiter }}')
+                    THEN ARRAY_TO_STRING(ARRAY(SELECT tokens[OFFSET(i)] FROM UNNEST(GENERATE_ARRAY({{ noOfColumns - 1 }}, ARRAY_LENGTH(tokens) - 1)) AS i), REGEXP_EXTRACT({{ quoted_column_name }}, {{ "r'" ~ pattern ~ "'" }}))
                 ELSE null
             END AS {{ quote_char ~ splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix ~ quote_char }}
         {%- else %}
             CASE
                 WHEN ARRAY_LENGTH(tokens) > {{ noOfColumns - 1 }}
-                    THEN REGEXP_REPLACE((tokens[OFFSET({{ noOfColumns - 1 }})]), r'^"|"$', '')
+                    THEN tokens[OFFSET({{ noOfColumns - 1 }})]
                 ELSE null
             END AS {{ quote_char ~ splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix ~ quote_char }}
         {%- endif %}
@@ -216,9 +230,9 @@ SELECT * FROM {{ relation_list | join(', ') }}
 
 {%- elif split_strategy == 'splitRows' -%}
     SELECT r.*,
-        REGEXP_REPLACE(split_value, r'[{}_]', ' ') AS {{ quote_char ~ splitRowsColumnName ~ quote_char }}
+        split_value AS {{ quote_char ~ splitRowsColumnName ~ quote_char }}
     FROM {{ relation_list | join(', ') }} r,
-    UNNEST(SPLIT(COALESCE(r.{{ quoted_column_name }}, ''), '{{ literal_delimiter }}')) AS split_value
+    UNNEST(SPLIT(REGEXP_REPLACE(COALESCE(r.{{ quoted_column_name }}, ''), {{ "r'" ~ pattern ~ "'" }}, '%%DELIM%%'), '%%DELIM%%')) AS split_value
 
 {%- else -%}
 SELECT * FROM {{ relation_list | join(', ') }}
@@ -242,41 +256,46 @@ SELECT * FROM {{ relation_list | join(', ') }}
 {%- set pattern = delimiter -%}
 {% set relation_list = relation_name if relation_name is iterable and relation_name is not string else [relation_name] %}
 {%- set quoted_column_name = prophecy_basics.quote_identifier(columnNames) -%}
+{%- set delimiter_literal = prophecy_basics.escape_sql_string(pattern, escape_backslashes=true) -%}
+{%- set leave_extra = (leaveExtraCharLastCol == true or leaveExtraCharLastCol == 'Leave extra in last column' or leaveExtraCharLastCol == 'true' or leaveExtraCharLastCol == 'True') -%}
 
 {%- if split_strategy == 'splitColumns' -%}
     WITH source AS (
         SELECT *,
             SPLIT(
-                REGEXP_REPLACE({{ quoted_column_name }}, {{ "'" ~ pattern ~ "'" }}, '%%DELIM%%'),
+                REGEXP_REPLACE({{ quoted_column_name }}, '{{ delimiter_literal }}', '%%DELIM%%'),
                 '%%DELIM%%'
             ) AS tokens
         FROM {{ relation_list | join(', ') }}
     ),
     all_data AS (
     SELECT *,
+        {# SPLIT() returns an ARRAY of VARIANT; cast to STRING so values are plain text
+           (no VARIANT quoting artifact) without altering the underlying content. #}
         {%- for i in range(1, noOfColumns) %}
-            TRIM(s.tokens[{{ i - 1 }}], '"') AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ i ~ '_' ~ splitColumnSuffix) }}{% if not loop.last or leaveExtraCharLastCol %}, {% endif %}
+            s.tokens[{{ i - 1 }}]::STRING AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ i ~ '_' ~ splitColumnSuffix) }},
         {%- endfor %}
-        {%- if leaveExtraCharLastCol == 'Leave extra in last column' or leaveExtraCharLastCol %}
+        {%- if leave_extra %}
             CASE
                 WHEN ARRAY_SIZE(s.tokens) >= {{ noOfColumns }}
-                    THEN ARRAY_TO_STRING(ARRAY_SLICE(s.tokens, {{ noOfColumns - 1 }}, ARRAY_SIZE(s.tokens)), '{{ delimiter }}')
+                    THEN ARRAY_TO_STRING(ARRAY_SLICE(s.tokens, {{ noOfColumns - 1 }}, ARRAY_SIZE(s.tokens)), REGEXP_SUBSTR({{ quoted_column_name }}, '{{ delimiter_literal }}'))
                 ELSE NULL
             END AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix) }}
         {%- else %}
-            s.tokens[{{ noOfColumns - 1 }}] AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix) }}
+            s.tokens[{{ noOfColumns - 1 }}]::STRING AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix) }}
         {%- endif %}
     FROM source AS s
     )
     SELECT * EXCLUDE(tokens) FROM all_data
 
 {%- elif split_strategy == 'splitRows' -%}
-    {%- set backslash_count = delimiter.count('\\') -%}
-    {%- set pattern = delimiter.replace('\\\\', '') if backslash_count % 2 == 1 else delimiter.replace('\\', '') -%}
     SELECT r.*,
-        REGEXP_REPLACE(s.value, '[{}_]', ' ') AS {{ prophecy_basics.quote_identifier(splitRowsColumnName) }}
+        s.value AS {{ prophecy_basics.quote_identifier(splitRowsColumnName) }}
     FROM {{ relation_list | join(', ') }} r,
-    LATERAL SPLIT_TO_TABLE(IFF({{ quoted_column_name }} IS NULL, '', {{ quoted_column_name }}), '{{ pattern }}') s
+    LATERAL SPLIT_TO_TABLE(
+        REGEXP_REPLACE(IFF({{ quoted_column_name }} IS NULL, '', {{ quoted_column_name }}), '{{ delimiter_literal }}', '%%DELIM%%'),
+        '%%DELIM%%'
+    ) s
 
 {%- else -%}
     SELECT * FROM {{ relation_list | join(', ') }}
@@ -297,32 +316,40 @@ SELECT * FROM {{ relation_list | join(', ') }}
     splitRowsColumnName
 ) -%}
 
-{# Handle escaped delimiters from Python - remove backslashes entirely #}
-{%- set pattern = delimiter.replace('\\', '') -%}
+{%- set pattern = delimiter -%}
 {% set relation_list = relation_name if relation_name is iterable and relation_name is not string else [relation_name] %}
-{# Handle string boolean parameter from Python - check string directly #}
 {%- set quoted_column = prophecy_basics.quote_identifier(columnNames) -%}
+{# Delimiter is treated as a regex: convert matches to a sentinel (global) then split on it. #}
+{%- set leave_extra = (leaveExtraCharLastCol == true or leaveExtraCharLastCol == 'Leave extra in last column' or leaveExtraCharLastCol == 'true' or leaveExtraCharLastCol == 'True') -%}
 
 {%- if split_strategy == 'splitColumns' -%}
     WITH source AS (
         SELECT *,
-            string_split({{ quoted_column }}, '{{ pattern }}') AS tokens
+            string_split(regexp_replace({{ quoted_column }}, '{{ pattern }}', '%%DELIM%%', 'g'), '%%DELIM%%') AS tokens
         FROM {{ relation_list | join(', ') }}
     ),
     all_data AS (
     SELECT *,
         {# Extract tokens positionally (DuckDB arrays are 1-indexed) #}
         {%- for i in range(1, noOfColumns) %}
-            regexp_replace((tokens[{{ i }}]), '^"|"$', '')
-            AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ i ~ '_' ~ splitColumnSuffix) }}{% if not loop.last or leaveExtraCharLastCol == 'Leave extra in last column' %},{% endif %}
+            tokens[{{ i }}] AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ i ~ '_' ~ splitColumnSuffix) }},
         {%- endfor %}
-        {%- if leaveExtraCharLastCol == 'Leave extra in last column' %}
+        {%- if leave_extra %}
+            {%- if noOfColumns == 1 %}
+            {# Single column: the whole (non-null) value is the last column. #}
+            {{ quoted_column }} AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix) }}
+            {%- else %}
+            {# Leave-extra: strip the first (noOfColumns-1) "<field><delimiter>" chunks so the
+               remainder keeps its ORIGINAL delimiter text. Uses a constant regex — DuckDBs
+               array_to_string separator must be constant, so regexp_extract() (per-row) is not
+               allowed here. (?s) lets the field span newlines. #}
             CASE
                 WHEN array_length(tokens) >= {{ noOfColumns }}
-                    THEN array_to_string(tokens[{{ noOfColumns }}:], '{{ pattern }}')
+                    THEN regexp_replace({{ quoted_column }}, '(?s)^(.*?{{ pattern }}){{ '{' ~ (noOfColumns - 1) ~ '}' }}', '')
                 ELSE null
             END AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix) }}
-        {%- else %}{% if noOfColumns > 1 %},{% endif %}
+            {%- endif %}
+        {%- else %}
             tokens[{{ noOfColumns }}] AS {{ prophecy_basics.quote_identifier(splitColumnPrefix ~ '_' ~ noOfColumns ~ '_' ~ splitColumnSuffix) }}
         {%- endif %}
     FROM source
@@ -332,18 +359,10 @@ SELECT * FROM {{ relation_list | join(', ') }}
 {%- elif split_strategy == 'splitRows' -%}
   SELECT
     r.*,
-    -- replace { } _ globally with spaces, collapse repeats, then trim
-    (
-      regexp_replace(
-        regexp_replace(s.col, '[{}_]', ' ', 'g'),
-        '\s+',
-        ' ',
-        'g'
-      )
-    ) AS {{ prophecy_basics.quote_identifier(splitRowsColumnName) }}
+    s.col AS {{ prophecy_basics.quote_identifier(splitRowsColumnName) }}
   FROM {{ relation_list | join(', ') }} r
   CROSS JOIN UNNEST(
-    string_split(coalesce(r.{{ quoted_column }}, ''), '{{ pattern }}')
+    string_split(regexp_replace(coalesce(r.{{ quoted_column }}, ''), '{{ pattern }}', '%%DELIM%%', 'g'), '%%DELIM%%')
   ) AS s(col)
 
 {%- else -%}

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.16.dev2
+version: 1.0.16.dev3
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.15
+version: 1.0.16.dev0
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
**Why Needed?**
To support regex patterns in DELIMETER of TextToColumns gem

Test cases
- Snowflake (tested)
```
https://preview.app.prophecy.ai/metadata/sql/16575?entity=pipeline&name=P1
```

- Databricks (tested)
```
https://preview.app.prophecy.ai/metadata/sql/57?entity=pipeline&name=P1
```
- Duckdb (tested)
```
https://staging.cloud.prophecy.io/metadata/sql/88732?entity=pipeline&name=P1
```
- BigQuery (tested)
```
https://staging.cloud.prophecy.io/metadata/sql/81272?entity=pipeline&name=P1
```

Asana link: https://app.asana.com/1/711615303573503/project/1214495747061385/task/1216619549698382?focus=true