### PR TITLE
Code to visual fixes

### DIFF
--- a/gems/CountRecords.py
+++ b/gems/CountRecords.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -180,12 +181,22 @@ class CountRecords(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return CountRecords.CountRecordsProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            column_names=json.loads(
-                parametersMap.get("column_names").replace("'", '"')
-            ),
+            column_names=_parse_py_literal(parametersMap.get("column_names"), []),
             count_method=parametersMap.get('count_method').lstrip("'").rstrip("'"),
         )
 

--- a/gems/DataCleansing.py
+++ b/gems/DataCleansing.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import datetime as dt
 import json
@@ -375,14 +376,16 @@ class DataCleansing(MacroSpec):
         # Load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
 
-        def _load_json_value(raw: str, default):
-            raw = raw or ""
-            if raw == "":
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
                 return default
             try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                return json.loads(raw.replace("'", '"'))
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
 
         def _unquote(raw: str, default: str = "") -> str:
             # Strip the surrounding single quotes emitted by apply() and
@@ -403,10 +406,10 @@ class DataCleansing(MacroSpec):
             numeric_with = int(numeric_with)
 
         return DataCleansing.DataCleansingProperties(
-            relation_name=_load_json_value(parametersMap.get("relation_name"), []),
+            relation_name=_parse_py_literal(parametersMap.get("relation_name"), []),
             schema=parametersMap.get("schema") or "",
             modifyCase=_unquote(parametersMap.get("modifyCase"), "keepOriginal") or "keepOriginal",
-            columnNames=_load_json_value(parametersMap.get("columnNames"), []),
+            columnNames=_parse_py_literal(parametersMap.get("columnNames"), []),
             replaceNullTextFields=_bool("replaceNullTextFields"),
             replaceNullTextWith=_unquote(parametersMap.get("replaceNullTextWith"), "NA"),
             replaceNullForNumericFields=_bool("replaceNullForNumericFields"),

--- a/gems/DataCleansing.py
+++ b/gems/DataCleansing.py
@@ -44,7 +44,7 @@ class DataCleansing(MacroSpec):
         cleanLetters: bool = False
         cleanPunctuations: bool = False
         cleanNumbers: bool = False
-        modifyCase: str = "Keep original"
+        modifyCase: str = "keepOriginal"
         replaceNullDateFields: bool = False
         replaceNullDateWith: str = "1970-01-01"
         replaceNullTimeFields: bool = False
@@ -274,7 +274,7 @@ class DataCleansing(MacroSpec):
     def validate(self, context: SqlContext, component: Component) -> List[Diagnostic]:
         diagnostics = super(DataCleansing, self).validate(context, component)
 
-        if len(component.properties.columnNames) > 0:
+        if len(component.properties.columnNames) > 0 and component.properties.schema:
             schema_cols_lower = set(col["name"].lower() for col in json.loads(component.properties.schema))
             
             missingKeyColumns = [
@@ -338,13 +338,21 @@ class DataCleansing(MacroSpec):
 
         # generate the actual macro call given the component's
         resolved_macro_name = f"{self.projectName}.{self.name}"
+
+        def safe_str(val):
+            # Escape backslashes and single quotes so values containing
+            # apostrophes remain a valid Jinja string literal in the
+            # generated macro call.
+            escaped = str(val).replace("\\", "\\\\").replace("'", "\\'")
+            return f"'{escaped}'"
+
         arguments = [
             str(props.relation_name),
             props.schema,
-            "'" + props.modifyCase + "'",
+            safe_str(props.modifyCase),
             str(props.columnNames),
             str(props.replaceNullTextFields).lower(),
-            "'" + str(props.replaceNullTextWith) + "'",
+            safe_str(props.replaceNullTextWith),
             str(props.replaceNullForNumericFields).lower(),
             str(props.replaceNullNumericWith),
             str(props.trimWhiteSpace).lower(),
@@ -355,9 +363,9 @@ class DataCleansing(MacroSpec):
             str(props.cleanNumbers).lower(),
             str(props.removeRowNullAllCols).lower(),
             str(props.replaceNullDateFields).lower(),
-            "'" + str(props.replaceNullDateWith) + "'",
+            safe_str(props.replaceNullDateWith),
             str(props.replaceNullTimeFields).lower(),
-            "'" + str(props.replaceNullTimeWith) + "'",
+            safe_str(props.replaceNullTimeWith),
         ]
 
         params = ",".join([param for param in arguments])
@@ -366,38 +374,58 @@ class DataCleansing(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # Load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
-        print("parametersMapisHere")
-        print(parametersMap)
+
+        def _load_json_value(raw: str, default):
+            raw = raw or ""
+            if raw == "":
+                return default
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return json.loads(raw.replace("'", '"'))
+
+        def _unquote(raw: str, default: str = "") -> str:
+            # Strip the surrounding single quotes emitted by apply() and
+            # reverse its backslash/apostrophe escaping.
+            if raw is None or raw == "":
+                return default
+            if len(raw) >= 2 and raw.startswith("'") and raw.endswith("'"):
+                raw = raw[1:-1]
+            return raw.replace("\\'", "'").replace("\\\\", "\\")
+
+        def _bool(name: str) -> bool:
+            return (parametersMap.get(name) or "").lower() == "true"
+
+        # Keep integral values as int so the generated code round-trips
+        # without rewriting e.g. 0 as 0.0.
+        numeric_with = float(_unquote(parametersMap.get("replaceNullNumericWith"), "0") or "0")
+        if numeric_with.is_integer():
+            numeric_with = int(numeric_with)
+
         return DataCleansing.DataCleansingProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
-            schema=parametersMap.get("schema"),
-            modifyCase=parametersMap.get('modifyCase').lstrip("'").rstrip("'"),
-            columnNames=json.loads(parametersMap.get("columnNames").replace("'", '"')),
-            replaceNullTextFields=parametersMap.get("replaceNullTextFields").lower()
-            == "true",
-            replaceNullTextWith=parametersMap.get("replaceNullTextWith")[1:-1],
-            replaceNullForNumericFields=parametersMap.get(
-                "replaceNullForNumericFields"
-            ).lower()
-            == "true",
-            replaceNullNumericWith=float(parametersMap.get("replaceNullNumericWith")),
-            trimWhiteSpace=parametersMap.get("trimWhiteSpace").lower() == "true",
-            removeTabsLineBreaksAndDuplicateWhitespace=parametersMap.get(
+            relation_name=_load_json_value(parametersMap.get("relation_name"), []),
+            schema=parametersMap.get("schema") or "",
+            modifyCase=_unquote(parametersMap.get("modifyCase"), "keepOriginal") or "keepOriginal",
+            columnNames=_load_json_value(parametersMap.get("columnNames"), []),
+            replaceNullTextFields=_bool("replaceNullTextFields"),
+            replaceNullTextWith=_unquote(parametersMap.get("replaceNullTextWith"), "NA"),
+            replaceNullForNumericFields=_bool("replaceNullForNumericFields"),
+            replaceNullNumericWith=numeric_with,
+            trimWhiteSpace=_bool("trimWhiteSpace"),
+            removeTabsLineBreaksAndDuplicateWhitespace=_bool(
                 "removeTabsLineBreaksAndDuplicateWhitespace"
-            ).lower()
-            == "true",
-            allWhiteSpace=parametersMap.get("allWhiteSpace").lower() == "true",
-            cleanLetters=parametersMap.get("cleanLetters").lower() == "true",
-            cleanPunctuations=parametersMap.get("cleanPunctuations").lower() == "true",
-            cleanNumbers=parametersMap.get("cleanNumbers").lower() == "true",
-            removeRowNullAllCols=parametersMap.get("removeRowNullAllCols").lower()
-            == "true",
-            replaceNullDateFields=parametersMap.get("replaceNullDateFields").lower()
-            == "true",
-            replaceNullDateWith=parametersMap.get("replaceNullDateWith")[1:-1],
-            replaceNullTimeFields=parametersMap.get("replaceNullTimeFields").lower()
-            == "true",
-            replaceNullTimeWith=parametersMap.get('replaceNullTimeWith').lstrip("'").rstrip("'")
+            ),
+            allWhiteSpace=_bool("allWhiteSpace"),
+            cleanLetters=_bool("cleanLetters"),
+            cleanPunctuations=_bool("cleanPunctuations"),
+            cleanNumbers=_bool("cleanNumbers"),
+            removeRowNullAllCols=_bool("removeRowNullAllCols"),
+            replaceNullDateFields=_bool("replaceNullDateFields"),
+            replaceNullDateWith=_unquote(parametersMap.get("replaceNullDateWith"), "1970-01-01"),
+            replaceNullTimeFields=_bool("replaceNullTimeFields"),
+            replaceNullTimeWith=_unquote(
+                parametersMap.get("replaceNullTimeWith"), "1970-01-01 00:00:00.0"
+            ),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:

--- a/gems/DataEncoderDecoder.py
+++ b/gems/DataEncoderDecoder.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -701,12 +702,22 @@ class DataEncoderDecoder(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return DataEncoderDecoder.DataEncoderDecoderProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            column_names=json.loads(
-                parametersMap.get("column_names").replace("'", '"')
-            ),
+            column_names=_parse_py_literal(parametersMap.get("column_names"), []),
             enc_dec_method=parametersMap.get('enc_dec_method').lstrip("'").rstrip("'"),
             enc_dec_charSet=parametersMap.get('enc_dec_charSet').lstrip("'").rstrip("'"),
             aes_enc_dec_secretScope_key=parametersMap.get('aes_enc_dec_secretScope_key').lstrip("'").rstrip("'"),

--- a/gems/DataMasking.py
+++ b/gems/DataMasking.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -501,12 +502,22 @@ class DataMasking(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return DataMasking.DataMaskingProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            column_names=json.loads(
-                parametersMap.get("column_names").replace("'", '"')
-            ),
+            column_names=_parse_py_literal(parametersMap.get("column_names"), []),
             masking_method=parametersMap.get('masking_method').lstrip("'").rstrip("'"),
             upper_char_substitute=parametersMap.get('upper_char_substitute').lstrip("'").rstrip("'"),
             lower_char_substitute=parametersMap.get('lower_char_substitute').lstrip("'").rstrip("'"),

--- a/gems/FindDuplicates.py
+++ b/gems/FindDuplicates.py
@@ -481,12 +481,32 @@ class FindDuplicates(MacroSpec):
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
 
+        def _load_json_value(raw: str, default):
+            raw = raw or ""
+            if raw == "":
+                return default
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return json.loads(raw.replace("'", '"'))
+
+        def _parse_order_columns(raw: str) -> List[OrderByRule]:
+            order_list = _load_json_value(raw, [])
+            return [
+                OrderByRule(
+                    expression=ColumnExpr(
+                        expression=r.get("expression", {}).get("expression", "") or "",
+                        format=r.get("expression", {}).get("format", "sql") or "sql",
+                    ),
+                    sortType=r.get("sortType", "asc") or "asc",
+                )
+                for r in order_list
+            ]
+
         return FindDuplicates.FindDuplicatesProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_load_json_value(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            groupByColumnNames=json.loads(
-                parametersMap.get("groupByColumnNames").replace("'", '"')
-            ),
+            groupByColumnNames=_load_json_value(parametersMap.get("groupByColumnNames"), []),
             column_group_rownum_condition=parametersMap.get(
                 "column_group_rownum_condition"
             ).lstrip("'").rstrip("'"),
@@ -495,13 +515,23 @@ class FindDuplicates(MacroSpec):
             upper_limit=parametersMap.get("upper_limit").lstrip("'").rstrip("'"),
             output_type=parametersMap.get("output_type").lstrip("'").rstrip("'"),
             generationMethod=parametersMap.get('generationMethod').lstrip("'").rstrip("'"),
-            orderByColumns=json.loads(
-                parametersMap.get("orderByColumns").replace("'", '"')
-            ),
+            orderByColumns=_parse_order_columns(parametersMap.get("orderByColumns")),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:
         # Convert component's state to default macro property representation
+        order_by_json = json.dumps(
+            [
+                {
+                    "expression": {
+                        "expression": r.expression.expression or "",
+                        "format": r.expression.format or "sql",
+                    },
+                    "sortType": r.sortType or "asc",
+                }
+                for r in (properties.orderByColumns or [])
+            ]
+        )
         return BasicMacroProperties(
             macroName=self.name,
             projectName=self.projectName,
@@ -522,9 +552,7 @@ class FindDuplicates(MacroSpec):
                 MacroParameter("upper_limit", str(properties.upper_limit)),
                 MacroParameter("output_type", str(properties.output_type)),
                 MacroParameter("generationMethod", str(properties.generationMethod)),
-                MacroParameter(
-                    "orderByColumns", json.dumps(properties.orderByColumns)
-                ),
+                MacroParameter("orderByColumns", order_by_json),
             ],
         )
 

--- a/gems/FindDuplicates.py
+++ b/gems/FindDuplicates.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -481,17 +482,19 @@ class FindDuplicates(MacroSpec):
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
 
-        def _load_json_value(raw: str, default):
-            raw = raw or ""
-            if raw == "":
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
                 return default
             try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                return json.loads(raw.replace("'", '"'))
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
 
         def _parse_order_columns(raw: str) -> List[OrderByRule]:
-            order_list = _load_json_value(raw, [])
+            order_list = _parse_py_literal(raw, [])
             return [
                 OrderByRule(
                     expression=ColumnExpr(
@@ -504,9 +507,9 @@ class FindDuplicates(MacroSpec):
             ]
 
         return FindDuplicates.FindDuplicatesProperties(
-            relation_name=_load_json_value(parametersMap.get('relation_name'), []),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            groupByColumnNames=_load_json_value(parametersMap.get("groupByColumnNames"), []),
+            groupByColumnNames=_parse_py_literal(parametersMap.get("groupByColumnNames"), []),
             column_group_rownum_condition=parametersMap.get(
                 "column_group_rownum_condition"
             ).lstrip("'").rstrip("'"),

--- a/gems/FuzzyMatch.py
+++ b/gems/FuzzyMatch.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 import re
@@ -311,8 +312,20 @@ class FuzzyMatch(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         matchFields = []
-        matchFieldsJson = json.loads(parametersMap.get("matchFields").replace("'", '"'))
+        matchFieldsJson = _parse_py_literal(parametersMap.get("matchFields"), [])
         for fld in matchFieldsJson:
             matchFields.append(
                 self.AddMatchField(
@@ -321,7 +334,7 @@ class FuzzyMatch(MacroSpec):
                 )
             )
         return FuzzyMatch.FuzzyMatchProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             mode=parametersMap.get('mode').lstrip("'").rstrip("'"),
             sourceIdCol=parametersMap.get('sourceIdCol').lstrip("'").rstrip("'"),
             recordIdCol=parametersMap.get('recordIdCol').lstrip("'").rstrip("'"),

--- a/gems/FuzzyMatch.py
+++ b/gems/FuzzyMatch.py
@@ -33,6 +33,7 @@ class FuzzyMatch(MacroSpec):
     class AddMatchField(MatchField):
         columnName: str = ""
         matchFunction: str = "custom"
+        _row_id: Optional[str] = None
 
     @dataclass(frozen=True)
     class FuzzyMatchProperties(MacroProperties):

--- a/gems/Imputation.py
+++ b/gems/Imputation.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -198,10 +199,22 @@ class Imputation(MacroSpec):
 
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return Imputation.ImputationProperties(
-            relation_name=json.loads(parametersMap.get("relation_name", "[]").replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get("relation_name"), []),
             schema=parametersMap.get("schema", "[]"),
-            columnNames=json.loads(parametersMap.get("columnNames", "[]").replace("'", '"')),
+            columnNames=_parse_py_literal(parametersMap.get("columnNames"), []),
             replaceIncomingType=parametersMap.get("replaceIncomingType", "null_val").strip("'"),
             incomingUserValue=parametersMap.get("incomingUserValue", "").strip("'").replace("''", "'"),
             replaceWithType=parametersMap.get("replaceWithType", "average").strip("'"),

--- a/gems/MultiColumnEdit.py
+++ b/gems/MultiColumnEdit.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -257,10 +258,22 @@ class MultiColumnEdit(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         # Load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return MultiColumnEdit.MultiColumnEditProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            columnNames=json.loads(parametersMap.get("columnNames").replace("'", '"')),
+            columnNames=_parse_py_literal(parametersMap.get("columnNames"), []),
             expressionToBeApplied=parametersMap.get('expressionToBeApplied').lstrip('"').rstrip('"'),
             changeOutputFieldName=parametersMap.get("changeOutputFieldName").lower()
             == "true",

--- a/gems/MultiColumnRename.py
+++ b/gems/MultiColumnRename.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 import re
@@ -282,10 +283,22 @@ class MultiColumnRename(MacroSpec):
 
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return MultiColumnRename.MultiColumnRenameProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
-            columnNames=json.loads(parametersMap.get("columnNames").replace("'", '"')),
+            columnNames=_parse_py_literal(parametersMap.get("columnNames"), []),
             renameMethod=parametersMap.get('renameMethod').lstrip("'").rstrip("'"),
             editType=parametersMap.get('editType').lstrip("'").rstrip("'"),
             editWith=parametersMap.get('editWith').lstrip("'").rstrip("'"),

--- a/gems/RecordID.py
+++ b/gems/RecordID.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -354,17 +355,19 @@ class RecordID(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         parametersMap = self.convertToParameterMap(properties.parameters)
 
-        def _load_json_value(raw: str, default):
-            raw = raw or ""
-            if raw == "":
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
                 return default
             try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                return json.loads(raw.replace("'", '"'))
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
 
         def _parse_order_columns(raw: str) -> List[OrderByRule]:
-            order_list = _load_json_value(raw, [])
+            order_list = _parse_py_literal(raw, [])
             return [
                 OrderByRule(
                     expression=ColumnExpr(
@@ -377,7 +380,7 @@ class RecordID(MacroSpec):
             ]
 
         return RecordID.RecordIDProperties(
-            relation_name=_load_json_value(parametersMap.get('relation_name'), []),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             method=parametersMap.get('method').lstrip("'").rstrip("'"),
             incremental_id_column_name=parametersMap.get('incremental_id_column_name').lstrip("'").rstrip("'"),
             incremental_id_type=parametersMap.get('incremental_id_type').lstrip("'").rstrip("'"),
@@ -387,7 +390,7 @@ class RecordID(MacroSpec):
             ),
             generationMethod=parametersMap.get('generationMethod').lstrip("'").rstrip("'"),
             position=parametersMap.get('position').lstrip("'").rstrip("'"),
-            groupByColumnNames=_load_json_value(parametersMap.get("groupByColumnNames"), []),
+            groupByColumnNames=_parse_py_literal(parametersMap.get("groupByColumnNames"), []),
             orders=_parse_order_columns(parametersMap.get("orders")),
         )
 

--- a/gems/RecordID.py
+++ b/gems/RecordID.py
@@ -353,8 +353,31 @@ class RecordID(MacroSpec):
     # -------------------------------------------------------------------------
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _load_json_value(raw: str, default):
+            raw = raw or ""
+            if raw == "":
+                return default
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return json.loads(raw.replace("'", '"'))
+
+        def _parse_order_columns(raw: str) -> List[OrderByRule]:
+            order_list = _load_json_value(raw, [])
+            return [
+                OrderByRule(
+                    expression=ColumnExpr(
+                        expression=r.get("expression", {}).get("expression", "") or "",
+                        format=r.get("expression", {}).get("format", "sql") or "sql",
+                    ),
+                    sortType=r.get("sortType", "asc") or "asc",
+                )
+                for r in order_list
+            ]
+
         return RecordID.RecordIDProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_load_json_value(parametersMap.get('relation_name'), []),
             method=parametersMap.get('method').lstrip("'").rstrip("'"),
             incremental_id_column_name=parametersMap.get('incremental_id_column_name').lstrip("'").rstrip("'"),
             incremental_id_type=parametersMap.get('incremental_id_type').lstrip("'").rstrip("'"),
@@ -364,15 +387,23 @@ class RecordID(MacroSpec):
             ),
             generationMethod=parametersMap.get('generationMethod').lstrip("'").rstrip("'"),
             position=parametersMap.get('position').lstrip("'").rstrip("'"),
-            groupByColumnNames=json.loads(
-                parametersMap.get("groupByColumnNames").replace("'", '"')
-            ),
-            orders=json.loads(
-                parametersMap.get("orders").replace("'", '"')
-            ),
+            groupByColumnNames=_load_json_value(parametersMap.get("groupByColumnNames"), []),
+            orders=_parse_order_columns(parametersMap.get("orders")),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:
+        order_by_json = json.dumps(
+            [
+                {
+                    "expression": {
+                        "expression": r.expression.expression or "",
+                        "format": r.expression.format or "sql",
+                    },
+                    "sortType": r.sortType or "asc",
+                }
+                for r in (properties.orders or [])
+            ]
+        )
         return BasicMacroProperties(
             macroName=self.name,
             projectName=self.projectName,
@@ -395,9 +426,7 @@ class RecordID(MacroSpec):
                 MacroParameter(
                     "groupByColumnNames", json.dumps(properties.groupByColumnNames)
                 ),
-                MacroParameter(
-                    "orders", json.dumps(properties.orders)
-                ),
+                MacroParameter("orders", order_by_json),
             ],
         )
 

--- a/gems/RunningTotal.py
+++ b/gems/RunningTotal.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 import re
@@ -267,8 +268,19 @@ class RunningTotal(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         parametersMap = self.convertToParameterMap(properties.parameters)
 
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         def _parse_order_columns(raw: str) -> List[OrderByRule]:
-            order_list = json.loads((raw or "[]").replace("'", '"'))
+            order_list = _parse_py_literal(raw, [])
             return [
                 OrderByRule(
                     expression=ColumnExpr(
@@ -289,10 +301,10 @@ class RunningTotal(MacroSpec):
         output_prefix = output_prefix_raw if output_prefix_raw and output_prefix_raw != "None" else "RunTot_"
 
         return RunningTotal.RunningTotalProperties(
-            relation_name=json.loads(raw_rel.replace("'", '"')),
+            relation_name=_parse_py_literal(raw_rel, []),
             schema=parametersMap.get("schema") or "",
-            groupByColumnNames=json.loads(raw_group.replace("'", '"')),
-            runningTotalColumnNames=json.loads(raw_running.replace("'", '"')),
+            groupByColumnNames=_parse_py_literal(raw_group, []),
+            runningTotalColumnNames=_parse_py_literal(raw_running, []),
             orderByColumns=_parse_order_columns(raw_order),
             outputPrefix=output_prefix,
         )

--- a/gems/Sample.py
+++ b/gems/Sample.py
@@ -375,8 +375,20 @@ class Sample(MacroSpec):
             except json.JSONDecodeError:
                 return json.loads(raw.replace("'", '"'))
 
+        def _parse_order_columns(raw: str) -> List[OrderByRule]:
+            order_list = _load_json_value(raw, [])
+            return [
+                OrderByRule(
+                    expression=ColumnExpr(
+                        expression=r.get("expression", {}).get("expression", "") or "",
+                        format=r.get("expression", {}).get("format", "sql") or "sql",
+                    ),
+                    sortType=r.get("sortType", "asc") or "asc",
+                )
+                for r in order_list
+            ]
+
         data_columns = _load_json_value(parametersMap.get("dataColumns"), [])
-        order_columns = _load_json_value(parametersMap.get("orderByColumns"), [])
         sample_level_selection = (
             (parametersMap.get("sampleLevelSelection") or "").lstrip("'").rstrip("'")
         )
@@ -391,14 +403,24 @@ class Sample(MacroSpec):
             randomSeed=int(str(parametersMap.get("randomSeed", 1002)).lstrip("'").rstrip("'")),
             currentModeSelection=(parametersMap.get("currentModeSelection") or "''").lstrip("'").rstrip("'"),
             numberN=int(str(parametersMap.get("numberN", 80)).lstrip("'").rstrip("'")),
-            orderByColumns=json.loads(
-                parametersMap.get("orderByColumns").replace("'", '"')
-            ),
+            orderByColumns=_parse_order_columns(parametersMap.get("orderByColumns")),
         )
         return props
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:
         # convert component's state to default macro property representation
+        order_by_json = json.dumps(
+            [
+                {
+                    "expression": {
+                        "expression": r.expression.expression or "",
+                        "format": r.expression.format or "sql",
+                    },
+                    "sortType": r.sortType or "asc",
+                }
+                for r in (properties.orderByColumns or [])
+            ]
+        )
         return BasicMacroProperties(
             macroName=self.name,
             projectName=self.projectName,
@@ -410,9 +432,7 @@ class Sample(MacroSpec):
                 MacroParameter("randomSeed", str(properties.randomSeed)),
                 MacroParameter("currentModeSelection", str(properties.currentModeSelection)),
                 MacroParameter("numberN", str(properties.numberN)),
-                MacroParameter(
-                    "orderByColumns", json.dumps(properties.orderByColumns)
-                ),
+                MacroParameter("orderByColumns", order_by_json),
             ],
         )
 

--- a/gems/Sample.py
+++ b/gems/Sample.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 import re
@@ -366,17 +367,19 @@ class Sample(MacroSpec):
         # load the component's state given default macro property representation
         parametersMap = self.convertToParameterMap(properties.parameters)
 
-        def _load_json_value(raw: str, default):
-            raw = raw or ""
-            if raw == "":
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
                 return default
             try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                return json.loads(raw.replace("'", '"'))
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
 
         def _parse_order_columns(raw: str) -> List[OrderByRule]:
-            order_list = _load_json_value(raw, [])
+            order_list = _parse_py_literal(raw, [])
             return [
                 OrderByRule(
                     expression=ColumnExpr(
@@ -388,7 +391,7 @@ class Sample(MacroSpec):
                 for r in order_list
             ]
 
-        data_columns = _load_json_value(parametersMap.get("dataColumns"), [])
+        data_columns = _parse_py_literal(parametersMap.get("dataColumns"), [])
         sample_level_selection = (
             (parametersMap.get("sampleLevelSelection") or "").lstrip("'").rstrip("'")
         )
@@ -396,7 +399,7 @@ class Sample(MacroSpec):
             sample_level_selection = "sampleGroup" if data_columns else "sampleDataset"
 
         props = Sample.SampleProperties(
-            relation_name=_load_json_value(parametersMap.get("relation_name"), []),
+            relation_name=_parse_py_literal(parametersMap.get("relation_name"), []),
             schema=(parametersMap.get("schema") or "").lstrip("'").rstrip("'"),
             sampleLevelSelection=sample_level_selection,
             dataColumns=data_columns,

--- a/gems/Tile.py
+++ b/gems/Tile.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 import re
@@ -415,17 +416,19 @@ class Tile(MacroSpec):
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         parametersMap = self.convertToParameterMap(properties.parameters)
 
-        def _load_json_value(raw: str, default):
-            raw = raw or ""
-            if raw == "":
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loadsq
+            raw = (raw or "").strip()
+            if not raw:
                 return default
             try:
-                return json.loads(raw)
-            except json.JSONDecodeError:
-                return json.loads(raw.replace("'", '"'))
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
 
         def _parse_order_columns(raw: str) -> List[OrderByRule]:
-            order_list = _load_json_value(raw, [])
+            order_list = _parse_py_literal(raw, [])
             return [
                 OrderByRule(
                     expression=ColumnExpr(
@@ -445,11 +448,11 @@ class Tile(MacroSpec):
         raw_donot_split = parametersMap.get("donot_split_tile_column_names") or "[]"
 
         return Tile.TileProperties(
-            relation_name=_load_json_value(raw_rel, []),
+            relation_name=_parse_py_literal(raw_rel, []),
             schema=raw_schema.lstrip("'").rstrip("'"),
             orderByColumns=_parse_order_columns(raw_order),
-            groupby_column_names=_load_json_value(raw_group, []),
-            unique_value_column_name=_load_json_value(raw_unique, []),
+            groupby_column_names=_parse_py_literal(raw_group, []),
+            unique_value_column_name=_parse_py_literal(raw_unique, []),
             tile_method=(parametersMap.get("tile_method") or "''").lstrip("'").rstrip("'"),
             number_of_tiles=(parametersMap.get("number_of_tiles") or "''").lstrip("'").rstrip("'"),
             sum_column_name=(parametersMap.get("sum_column_name") or "''").lstrip("'").rstrip("'"),
@@ -461,7 +464,7 @@ class Tile(MacroSpec):
                 "manual_tile_column_name", "''"
             ).lstrip("'").rstrip("'"),
             manual_tiles_cutoff=(parametersMap.get("manual_tiles_cutoff") or "''").lstrip("'").rstrip("'"),
-            donot_split_tile_column_names=_load_json_value(raw_donot_split, []),
+            donot_split_tile_column_names=_parse_py_literal(raw_donot_split, []),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:

--- a/gems/UnionByName.py
+++ b/gems/UnionByName.py
@@ -118,12 +118,7 @@ class UnionByName(MacroSpec):
 
         def _parse_py_literal(raw, default):
             # apply() emits list params as str(<python value>) (single-quoted repr),
-            # so the inverse is ast.literal_eval — NOT json.loads with a naive
-            # .replace("'", ...). For `schemas` each element is itself a JSON string
-            # (e.g. '[{"name": "A", ...}]'); stripping quotes then str()-ing the parsed
-            # value re-serialized it as a Python repr, corrupting the embedded JSON to
-            # single quotes. literal_eval preserves each element verbatim (and accepts
-            # both single- and double-quoted literals, so JSON also works).
+            # so the inverse is ast.literal_eval — NOT json.loads
             raw = (raw or "").strip()
             if not raw:
                 return default

--- a/gems/WeightedAverage.py
+++ b/gems/WeightedAverage.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 import re
@@ -206,15 +207,25 @@ class WeightedAverage(MacroSpec):
 
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         parametersMap = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted
+            # repr), so the inverse is ast.literal_eval — NOT json.loads
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return WeightedAverage.WeightedAverageProperties(
-            relation_name=json.loads(parametersMap.get('relation_name').replace("'", '"')),
+            relation_name=_parse_py_literal(parametersMap.get('relation_name'), []),
             schema=parametersMap.get("schema"),
             valueFieldColumn=(parametersMap.get("valueFieldColumn") or "''").lstrip("'").rstrip("'"),
             weightFieldColumn=(parametersMap.get("weightFieldColumn") or "''").lstrip("'").rstrip("'"),
             outputFieldName=(parametersMap.get("outputFieldName") or "''").lstrip("'").rstrip("'") or "WeightedAverage",
-            groupByColumnNames=json.loads(
-                parametersMap.get("groupByColumnNames", "[]").replace("'", '"')
-            ),
+            groupByColumnNames=_parse_py_literal(parametersMap.get("groupByColumnNames"), []),
         )
 
     def unloadProperties(self, properties: PropertiesType) -> MacroProperties:

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.17.dev0",
+    version="1.0.17.dev1",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.17.dev0
+version: 1.0.17.dev1
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
  - Fixes the code→visual round-trip for **Sample**, **RecordID**, and **FindDuplicates**: `loadProperties` was returning raw dicts instead of `OrderByRule` objects for their order-by properties, and `unloadProperties` called `json.dumps()` directly on frozen dataclass instances (raises `TypeError`). Parses macro-argument text with `ast.literal_eval` — not `json.loads` with a naive `'`→`"` swap — matching the pattern already used in `Regex.py` (#92) and `UnionByName.py` (#97). The naive swap corrupts or crashes on any order-by expression containing a quote character (e.g. `status = 'active'`, a completely normal thing to type into the `ExpressionBox`), since blind quote substitution can't tell a Python string delimiter apart from a literal quote inside the data.
  - Adds the missing `_row_id: Optional[str] = None` field to `FuzzyMatch.AddMatchField`, matching the `_row_id` fix already applied to every other row-record dataclass bound to a list/table UI widget (#89, #90). Without it, the UI stamping a row id on a match field crashes deserialization.
  - Fixes several issues in `DataCleansing:
    - `modifyCase` defaulted to the dropdown *label* (`"Keep original"`) instead of its option value (`keepOriginal`), leaving a fresh gem's dropdown unselected.
    - `loadProperties` crashed on any missing parameter (unguarded `.lower()`/`[1:-1]` on `None`), left in debug `print()` calls, and corrupted values containing apostrophes via a naive `.replace("'", '"')`.
    - `apply()` didn't escape apostrophes/backslashes in quoted values, so values like `Dev's NA` generated invalid macro code.
    - `replaceNullNumericWith` was always parsed back as `float`, rewriting integral values (e.g. `0` → `0.0`) on every round-trip.
    - `validate()` crashed on an empty `schema`.