### PR TITLE
Fix code to visual for union gem

### DIFF
--- a/gems/UnionByName.py
+++ b/gems/UnionByName.py
@@ -1,3 +1,4 @@
+import ast
 import dataclasses
 import json
 
@@ -114,9 +115,26 @@ class UnionByName(MacroSpec):
 
     def loadProperties(self, properties: MacroProperties) -> PropertiesType:
         pm = self.convertToParameterMap(properties.parameters)
+
+        def _parse_py_literal(raw, default):
+            # apply() emits list params as str(<python value>) (single-quoted repr),
+            # so the inverse is ast.literal_eval — NOT json.loads with a naive
+            # .replace("'", ...). For `schemas` each element is itself a JSON string
+            # (e.g. '[{"name": "A", ...}]'); stripping quotes then str()-ing the parsed
+            # value re-serialized it as a Python repr, corrupting the embedded JSON to
+            # single quotes. literal_eval preserves each element verbatim (and accepts
+            # both single- and double-quoted literals, so JSON also works).
+            raw = (raw or "").strip()
+            if not raw:
+                return default
+            try:
+                return ast.literal_eval(raw)
+            except (ValueError, SyntaxError):
+                return default
+
         return UnionByName.UnionByNameProperties(
-            relation_name=json.loads(pm.get("relation_name", "[]").replace("'", '"')),
-            schemas=[str(x) for x in json.loads(pm.get("schemas", "[]").replace("'", ''))],
+            relation_name=_parse_py_literal(pm.get("relation_name", "[]"), []),
+            schemas=_parse_py_literal(pm.get("schemas", "[]"), []),
             missingColumnOps=pm.get("missingColumnOps", "nameBasedUnionOperation").lstrip("'").rstrip("'"),
         )
 

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.16.dev1",
+    version="1.0.16.dev2",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.16.dev0",
+    version="1.0.16.dev1",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/macros/UnionByName.sql
+++ b/macros/UnionByName.sql
@@ -7,7 +7,7 @@
   are filled with nulls, or you can require every table to match the first exactly.
 
   Parameters:
-    - relation_names (list): Relation identifiers to union (e.g. `['a', 'b']`).
+    - relation_name (list): Relation identifiers to union (e.g. `['a', 'b']`).
     - schemas (list): Parallel list of schemas (JSON string or list of {name, ...} fields).
     - missingColumnOps: 'allowMissingColumns' (union of all columns, NULL where absent) or
         'nameBasedUnionOperation' (strict: compiler error on extra/missing vs first relation).
@@ -34,21 +34,21 @@
       )
       select * from union_query
 #}
-{% macro UnionByName(relation_names,
+{% macro UnionByName(relation_name,
                      schemas,
                      missingColumnOps='allowMissingColumns') -%}
-    {{ return(adapter.dispatch('UnionByName', 'prophecy_basics')(relation_names, schemas, missingColumnOps)) }}
+    {{ return(adapter.dispatch('UnionByName', 'prophecy_basics')(relation_name, schemas, missingColumnOps)) }}
 {% endmacro %}
 
-{% macro default__UnionByName(relation_names,
+{% macro default__UnionByName(relation_name,
                      schemas,
                      missingColumnOps='allowMissingColumns') -%}
 
     {# Step 1: Normalize relation list #}
-    {%- if relation_names is string -%}
-        {%- set relations = relation_names.split(',') | map('trim') | list -%}
+    {%- if relation_name is string -%}
+        {%- set relations = relation_name.split(',') | map('trim') | list -%}
     {%- else -%}
-        {%- set relations = relation_names | list -%}
+        {%- set relations = relation_name | list -%}
     {%- endif -%}
 
     {# Step 2: Capture column names AND build norm→actual dict per relation #}
@@ -162,15 +162,15 @@
 
 {%- endmacro %}
 
-{% macro snowflake__UnionByName(relation_names,
+{% macro snowflake__UnionByName(relation_name,
                      schemas,
                      missingColumnOps='allowMissingColumns') -%}
 
     {# Step 1: Normalize relation list #}
-    {%- if relation_names is string -%}
-        {%- set relations = relation_names.split(',') | map('trim') | list -%}
+    {%- if relation_name is string -%}
+        {%- set relations = relation_name.split(',') | map('trim') | list -%}
     {%- else -%}
-        {%- set relations = relation_names | list -%}
+        {%- set relations = relation_name | list -%}
     {%- endif -%}
 
     {# Step 2: Capture column names AND build norm→actual dict per relation #}
@@ -284,15 +284,15 @@
 
 {%- endmacro %}
 
-{% macro duckdb__UnionByName(relation_names,
+{% macro duckdb__UnionByName(relation_name,
                      schemas,
                      missingColumnOps='allowMissingColumns') -%}
 
     {# Step 1: Normalize relation list #}
-    {%- if relation_names is string -%}
-        {%- set relations = relation_names.split(',') | map('trim') | list -%}
+    {%- if relation_name is string -%}
+        {%- set relations = relation_name.split(',') | map('trim') | list -%}
     {%- else -%}
-        {%- set relations = relation_names | list -%}
+        {%- set relations = relation_name | list -%}
     {%- endif -%}
 
     {# Step 2: Capture column names AND build norm→actual dict per relation #}

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.16.dev0
+version: 1.0.16.dev1
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.16.dev1
+version: 1.0.16.dev2
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
## Fix UnionByName code↔visual round-trip                                                                                                                                                 

`loadProperties` parsed the schemas argument with `[str(x) for x in json.loads(raw.replace("'", ''))]`. Stripping all single quotes collapsed the list-of-JSON-strings into nested Python objects, and str() then re-serialized them as Python reprs turning valid JSON like `[{"name": "A", ...}]` into `[{'name': 'A', ...}]`. That single-quoted output was written back into the SQL on every code→visual pass, breaking the macro's JSON.                                                                                                                                                                                                  
                                                                                                                                                                                                                 
Fixed by parsing both relation_name and schemas with `ast.literal_eval`, the correct inverse of apply()'s str() which preserves each element verbatim and keeps the embedded double-quoted JSON intact, making the round-trip stable. (Same approach as the Regex loadProperties fix in #92.)