### PR TITLE
Fuzzymatch - remove regex replace of punctuations

### DIFF
--- a/gems/FuzzyMatch.py
+++ b/gems/FuzzyMatch.py
@@ -379,7 +379,7 @@ class FuzzyMatch(MacroSpec):
             col_name = field.columnName
 
             if key in ("custom", "name", "address"):
-                column_value = upper(regexp_replace(col(col_name).cast("string"), r"[^\w\s]", ""))
+                column_value = upper(col(col_name).cast("string"))
             else:
                 column_value = col(col_name).cast("string")
 

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prophecy_basics",
-    version="1.0.17.dev0",
+    version="1.0.17.dev1",
     packages=["prophecy_basics"],
     package_dir={"prophecy_basics": "."},
     description="",

--- a/macros/FuzzyMatch.sql
+++ b/macros/FuzzyMatch.sql
@@ -91,15 +91,8 @@
         {%- endif -%}
 
         {%- set quoted_col = prophecy_basics.quote_identifier(col) -%}
-        {%- if key == 'custom' -%}
-            {# For custom matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS STRING), '[[:punct:]]', ''))" -%}
-        {%- elif key == 'name' -%}
-            {# For name matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS STRING), '[[:punct:]]', ''))" -%}
-        {%- elif key == 'address' -%}
-            {# For address matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS STRING), '[[:punct:]]', ''))" -%}
+        {%- if key in ('custom', 'name', 'address') -%}
+            {%- set column_value_expr = "UPPER(CAST(" ~ quoted_col ~ " AS STRING))" -%}
         {%- else -%}
             {%- set column_value_expr = "CAST(" ~ quoted_col ~ " AS STRING)" -%}
         {%- endif -%}
@@ -242,15 +235,8 @@ final_output as (
         {%- endif -%}
 
         {%- set quoted_col = prophecy_basics.quote_identifier(col) -%}
-        {%- if key == 'custom' -%}
-            {# For custom matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS STRING), r'[^a-zA-Z0-9\\s]', ''))" -%}
-        {%- elif key == 'name' -%}
-            {# For name matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS STRING), r'[^a-zA-Z0-9\\s]', ''))" -%}
-        {%- elif key == 'address' -%}
-            {# For address matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS STRING), r'[^a-zA-Z0-9\\s]', ''))" -%}
+        {%- if key in ('custom', 'name', 'address') -%}
+            {%- set column_value_expr = "UPPER(CAST(" ~ quoted_col ~ " AS STRING))" -%}
         {%- else -%}
             {%- set column_value_expr = "CAST(" ~ quoted_col ~ " AS STRING)" -%}
         {%- endif -%}
@@ -399,8 +385,7 @@ final_output as (
 
         {%- set quoted_col = prophecy_basics.quote_identifier(col) -%}
         {%- if key in ('custom', 'name', 'address') -%}
-            {# Strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS VARCHAR), '[[:punct:]]', ''))" -%}
+            {%- set column_value_expr = "UPPER(CAST(" ~ quoted_col ~ " AS VARCHAR))" -%}
         {%- else -%}
             {%- set column_value_expr = "CAST(" ~ quoted_col ~ " AS VARCHAR)" -%}
         {%- endif -%}
@@ -549,15 +534,8 @@ final_output as (
         {%- endif -%}
 
         {%- set quoted_col = prophecy_basics.quote_identifier(col) -%}
-        {%- if key == 'custom' -%}
-            {# For custom matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS VARCHAR), '[[:punct:]]', ''))" -%}
-        {%- elif key == 'name' -%}
-            {# For name matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS VARCHAR), '[[:punct:]]', ''))" -%}
-        {%- elif key == 'address' -%}
-            {# For address matching, strip punctuation from the column value #}
-            {%- set column_value_expr = "UPPER(REGEXP_REPLACE(CAST(" ~ quoted_col ~ " AS VARCHAR), '[[:punct:]]', ''))" -%}
+        {%- if key in ('custom', 'name', 'address') -%}
+            {%- set column_value_expr = "UPPER(CAST(" ~ quoted_col ~ " AS VARCHAR))" -%}
         {%- else -%}
             {%- set column_value_expr = "CAST(" ~ quoted_col ~ " AS VARCHAR)" -%}
         {%- endif -%}

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: prophecy_basics
 description: ''
-version: 1.0.17.dev0
+version: 1.0.17.dev1
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
**Existing functionality**
FuzzyMatch punctuation removal is incorrect. In the existing gem, we were generating incorrect results (similarity score) because we were removing punctuations without client's concent.

**Changes**
We have removed the logic of removing punctuations 

Asana: https://app.asana.com/1/711615303573503/project/1214496305764586/task/1214599601772534?focus=true

**Dev Tests**
<img width="622" height="153" alt="image" src="https://github.com/user-attachments/assets/f7f2c6db-6198-4a1d-8e55-cbfb302d1504" />

<img width="1155" height="245" alt="image" src="https://github.com/user-attachments/assets/ab0c6734-75eb-4f13-9cd0-b9834c472d13" />
